### PR TITLE
Update GeoJSON for Subdistrict ID

### DIFF
--- a/rtsd_pat.geojson
+++ b/rtsd_pat.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1001d92a0bc01a43d76d6a278ae295fdfc4dd722f0c1f7f3ec5eafe28b45c20d
+oid sha256:0c0bcc1686d34935c14ec10ac05a5063124a8e6967a6b633810df309970149bb
 size 705686247


### PR DESCRIPTION
This pull request updates the subdistrict ID and administrative assignments in the GeoJSON data to reflect more accurate administrative boundaries.

Changes Made:
- Updated the ID of `แขวงบางนาเหนือ` to `104702` to align with official subdistrict coding.
Reassigned `ตำบลท่าแฝก` from `อำเภอท่าปลา` to `อำเภอน้ำปาด`, and updated its subdistrict ID to `530407`.

These changes help ensure that the subdistrict codes and administrative structures in the map data are consistent with the latest administrative divisions.